### PR TITLE
Add configurable DNS resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,25 @@ rm -rf /h-ui
 Export the user, system configuration, and Hysteria2 configuration in the management background, redeploy the latest
 version of h-ui, and import the data into the management background after the deployment is complete.
 
+## DNS options (advanced, opt-in)
+
+By default h-ui uses the OS resolver. If your environment has issues with UDP/EDNS
+(e.g. forwarders returning SERVFAIL for AAAA), you can switch to Go resolver and/or force TCP
+to the same nameservers from /etc/resolv.conf:
+
+- `HUI_DNS_PREFER_GO=1`          # use Go resolver
+- `HUI_DNS_TRANSPORT=tcp|udp`    # force transport to nameserver (default: OS)
+- `HUI_DNS_FORCE_TCP=1`          # shorthand for TRANSPORT=tcp
+- `HUI_DNS_IPV4_ONLY=1`          # use tcp4/udp4 to nameserver (does not disable AAAA queries)
+- `HUI_DNS_TIMEOUT=2s`           # dial timeout to nameserver
+- `HUI_DNS_STRICT_ERRORS=0|1`    # pass-through to net.Resolver.StrictErrors (default: 0)
+
+Example:
+
+```bash
+HUI_DNS_PREFER_GO=1 HUI_DNS_TRANSPORT=tcp ./h-ui-linux-amd64 -p 4433
+```
+
 ## FAQ
 
 [English > FAQ](./docs/FAQ.md)

--- a/dns_init.go
+++ b/dns_init.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+func envBool(k string) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(k)))
+	return v == "1" || v == "true" || v == "yes" || v == "on"
+}
+
+func envStr(k, def string) string {
+	if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+		return v
+	}
+	return def
+}
+
+func init() {
+	if os.Getenv("HUI_DNS_PREFER_GO") == "" &&
+		os.Getenv("HUI_DNS_TRANSPORT") == "" &&
+		os.Getenv("HUI_DNS_FORCE_TCP") == "" &&
+		os.Getenv("HUI_DNS_IPV4_ONLY") == "" &&
+		os.Getenv("HUI_DNS_TIMEOUT") == "" &&
+		os.Getenv("HUI_DNS_STRICT_ERRORS") == "" {
+		return
+	}
+
+	preferGo := envBool("HUI_DNS_PREFER_GO")
+	strict := envBool("HUI_DNS_STRICT_ERRORS")
+
+	transport := strings.ToLower(envStr("HUI_DNS_TRANSPORT", ""))
+	if transport == "" && envBool("HUI_DNS_FORCE_TCP") {
+		transport = "tcp"
+	}
+	ipv4Only := envBool("HUI_DNS_IPV4_ONLY")
+
+	timeout := 2 * time.Second
+	if t := envStr("HUI_DNS_TIMEOUT", ""); t != "" {
+		if d, err := time.ParseDuration(t); err == nil {
+			timeout = d
+		}
+	}
+
+	net.DefaultResolver = &net.Resolver{
+		PreferGo:     preferGo || transport != "" || ipv4Only,
+		StrictErrors: strict,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			netw := network
+			switch transport {
+			case "tcp":
+				netw = "tcp"
+			case "udp":
+				netw = "udp"
+			}
+			if ipv4Only {
+				if strings.HasPrefix(netw, "tcp") {
+					netw = "tcp4"
+				} else {
+					netw = "udp4"
+				}
+			}
+			d := &net.Dialer{Timeout: timeout}
+			return d.DialContext(ctx, netw, address)
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add environment-driven DNS resolver allowing Go resolver, transport selection, IPv4-only mode, timeout and strict error settings
- document DNS configuration options in README

## Testing
- `go test ./...` *(fails: pattern dist/*: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68993ec8f12c832da31647f6929e2481