### PR TITLE
Prevent nil pointer when Telegram bot init fails

### DIFF
--- a/controller/account.go
+++ b/controller/account.go
@@ -11,6 +11,7 @@ import (
 	"h-ui/service"
 	"h-ui/util"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -35,7 +36,10 @@ func Login(c *gin.Context) {
 		TokenType:   constant.TokenType,
 		AccessToken: token,
 	}
-	service.TelegramLoginRemind(*loginDto.Username, c.ClientIP())
+	if err := service.TelegramLoginRemind(*loginDto.Username, c.ClientIP()); err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"msg": "Telegram unreachable", "error": err.Error()})
+		return
+	}
 	vo.Success(jwtVo, c)
 }
 


### PR DESCRIPTION
## Summary
- handle Telegram bot initialization and message send errors instead of panicking
- return error from TelegramLoginRemind and surface failure in login controller

## Testing
- `go test ./...` *(fails: frontend/embed.go:13:12: pattern dist/*: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_689958c2a464832d8cc750a49bef14e4