### PR TITLE
feat: support IPv6 lookups without EDNS

### DIFF
--- a/dao/config.go
+++ b/dao/config.go
@@ -33,6 +33,9 @@ func UpdateConfig(keys []string, updates map[string]interface{}) error {
 
 func GetConfig(query interface{}, args ...interface{}) (entity.Config, error) {
 	var config entity.Config
+	if sqliteDB == nil {
+		return config, errors.New(constant.SysError)
+	}
 	if tx := sqliteDB.Model(&entity.Config{}).
 		Where(query, args...).First(&config); tx.Error != nil {
 		if tx.Error == gorm.ErrRecordNotFound {

--- a/service/telegram.go
+++ b/service/telegram.go
@@ -48,7 +48,7 @@ func valid() (string, string, error) {
 }
 
 func InitTelegramBot() error {
-	logrus.Info("dns resolver: no-edns=DEFAULT (A-only, UDP 512, no OPT)")
+	logrus.Info("dns resolver: no-edns=DEFAULT (A/AAAA over UDP 512, no OPT)")
 	token, chatId, err := valid()
 	if err != nil {
 		if err.Error() == "telegram not enable" {
@@ -65,11 +65,12 @@ func InitTelegramBot() error {
 			if err != nil {
 				return nil, err
 			}
-			ip, err := res.LookupAOnce(ctx, host)
+			ip, err := res.LookupAnyOnce(ctx, host)
 			if err != nil {
 				return nil, err
 			}
-			return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			dialAddr := net.JoinHostPort(ip.String(), port)
+			return dialer.DialContext(ctx, "tcp", dialAddr)
 		},
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
## Summary
- add generic NoEDNS resolver helper to query both A and AAAA records
- try IPv6 addresses when connecting to Telegram and dial using IP literals
- avoid panic when configuration database is uninitialized

## Testing
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_689966fcc68c832d9fedc5d018beedb9